### PR TITLE
Don't skip when voiding string

### DIFF
--- a/modules/core/src/main/scala/parser/TextParser.scala
+++ b/modules/core/src/main/scala/parser/TextParser.scala
@@ -60,7 +60,6 @@ object TextParser {
      */
     def string(s: String): Parser[String] =
       new Parser[String](s"string($s)") {
-        override lazy val void = skip(s.length)
         def mutParse(mutState: MutState): String =
           if (mutState.startsWith(s)) {
             mutState.advance(s.length)


### PR DESCRIPTION
We can't just skip when voiding a string parser, because we still need to verify what we skipped.

Before:

```scala
scala> "false".void.parse("true!")
res1: a22o.Result[Unit] = Result.Ok(())
```

After:

```scala
scala> "false".void.parse("true?")
res6: a22o.Result[Unit] = Result.Error(string: no match)
```

Uh, the types are the tests.